### PR TITLE
Improve dist_iter test coverage

### DIFF
--- a/tests/test_10_dist_iter.py
+++ b/tests/test_10_dist_iter.py
@@ -1,5 +1,5 @@
 import logging
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from partis.pyproj.pptoml import pyproj_dist_copy
 from partis.pyproj.dist_file.dist_copy import dist_iter
@@ -35,5 +35,5 @@ def test_dist_iter_strip_and_replace(tmp_path):
     assert len(items) == 1
     _, src_file, dst_file, _, individual = items[0]
     assert src_file == file_path
-    assert dst_file == Path('dest') / 'original.dat'
+    assert dst_file == PurePosixPath('dest') / 'original.dat'
     assert not individual

--- a/tests/test_10_dist_iter.py
+++ b/tests/test_10_dist_iter.py
@@ -1,0 +1,39 @@
+import logging
+from pathlib import Path
+
+from partis.pyproj.pptoml import pyproj_dist_copy
+from partis.pyproj.dist_file.dist_copy import dist_iter
+
+
+def test_dist_iter_strip_and_replace(tmp_path):
+    src = tmp_path / "src"
+    sub = src / "sub"
+    sub.mkdir(parents=True)
+    file_path = sub / "original.txt"
+    file_path.write_text("data")
+
+    copy_item = pyproj_dist_copy({
+        'src': src,
+        'dst': Path('dest'),
+        'include': [
+            {
+                'glob': 'sub/*.txt',
+                'rematch': r'(.*)\.txt',
+                'replace': '{1}.dat',
+                'strip': 1,
+            }
+        ]
+    })
+
+    items = list(dist_iter(
+        copy_items=[copy_item],
+        ignore=[],
+        root=tmp_path,
+        logger=logging.getLogger(__name__),
+    ))
+
+    assert len(items) == 1
+    _, src_file, dst_file, _, individual = items[0]
+    assert src_file == file_path
+    assert dst_file == Path('dest') / 'original.dat'
+    assert not individual


### PR DESCRIPTION
## Summary
- add new test ensuring `dist_iter` correctly applies `strip` and `replace`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b0400c608332824bdff41c021379