### PR TITLE
Add tests for download caching and template namespace

### DIFF
--- a/src/pyproj/file.py
+++ b/src/pyproj/file.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import os
 
 #===============================================================================
-def tail(path, n, bufsize = 1024, encoding = 'utf-8'):
+def tail(path, n, bufsize = 1024, encoding = 'utf-8') -> list[str]:
   """Reads the last n lines from a file
 
   Parameters
@@ -15,7 +15,7 @@ def tail(path, n, bufsize = 1024, encoding = 'utf-8'):
 
   Returns
   -------
-  lines : List[str]
+  lines:
     Up to ``n`` lines from the end of the file
   """
 
@@ -25,18 +25,21 @@ def tail(path, n, bufsize = 1024, encoding = 'utf-8'):
   n = int(n)
   n = max( 0, n )
 
+  if n == 0:
+    return []
+
   buf = bytes()
   nlines = 0
 
   head = 0
 
-  with open( path, 'rb' ) as fp:
+  with open(path, 'rb') as fp:
     # total number of bytes in the file
     tot = fp.seek( 0, os.SEEK_END )
 
     head = tot
 
-    while nlines < n and head > 0:
+    while nlines <= n and head > 0:
       # NOTE: the number of newline characters is one less than number of 'lines'
       nread = min( head, bufsize )
       head -= nread

--- a/src/pyproj/file.py
+++ b/src/pyproj/file.py
@@ -28,6 +28,7 @@ def tail(path, n, bufsize = 1024, encoding = 'utf-8') -> list[str]:
   if n == 0:
     return []
 
+  sep = b'\n' if '\n' in os.linesep else b'\r'
   buf = bytes()
   nlines = 0
 
@@ -47,19 +48,13 @@ def tail(path, n, bufsize = 1024, encoding = 'utf-8') -> list[str]:
       fp.seek( head, os.SEEK_SET )
 
       _buf = fp.read( nread )
-
-      # NOTE: this is not exact, since pairs of '\r\n' may happen on the read
-      # boundary, but should count approximately the number of LF, CR, and CR+LF.
-      # LF -> 1 + 0 + 0 = 1
-      # CR -> 0 + 1 + 0 = 1
-      # CR+LF -> 1 + 1 - 1 = 1
-      nlines += _buf.count(b'\n') + _buf.count(b'\r') - _buf.count(b'\r\n')
+      nlines += _buf.count(sep)
 
       buf = _buf + buf
 
   if nlines > 0 and head > 0:
     # remove everything before first newline to ensure only complete lines are kept
-    i = buf.index(b'\n')
+    i = buf.index(sep)
     buf = buf[(i+1):]
 
   res = buf.decode(encoding, errors = 'replace')

--- a/src/pyproj/file.py
+++ b/src/pyproj/file.py
@@ -60,6 +60,6 @@ def tail(path, n, bufsize = 1024, encoding = 'utf-8'):
     buf = buf[(i+1):]
 
   res = buf.decode(encoding, errors = 'replace')
-  lines = res.split('\n')[-n:]
+  lines = res.splitlines()[-n:]
 
   return lines

--- a/tests/test_11_tail_and_process.py
+++ b/tests/test_11_tail_and_process.py
@@ -1,5 +1,4 @@
-import os
-import tempfile
+from pathlib import Path
 import logging
 
 import pytest
@@ -17,7 +16,7 @@ class DummyRunner:
         self.commands.append(cmd)
 
 
-def test_tail_basic_and_bufsize(tmp_path):
+def test_tail_basic_and_bufsize(tmp_path: Path):
   file = tmp_path/'out.txt'
   file.write_text("a\nb\nc\n")
 

--- a/tests/test_11_tail_and_process.py
+++ b/tests/test_11_tail_and_process.py
@@ -17,30 +17,19 @@ class DummyRunner:
         self.commands.append(cmd)
 
 
-def test_tail_basic_and_bufsize():
-    # create a temporary file with multiple lines
-    with tempfile.NamedTemporaryFile("w+", delete=False) as tmp:
-        tmp.write("a\n" + "b\n" + "c\n")
-        name = tmp.name
+def test_tail_basic_and_bufsize(tmp_path):
+  file = tmp_path/'out.txt'
+  file.write_text("a\nb\nc\n")
 
-    try:
-        # requesting more lines than available should return all lines
-        assert tail(name, 10) == ["a", "b", "c", ""]
-        # requesting last two lines with small buffer to force multiple reads
-        assert tail(name, 2, bufsize=2) == ["c", ""]
-    finally:
-        os.unlink(name)
-
-
-def test_tail_zero_or_negative():
-    with tempfile.NamedTemporaryFile("w+", delete=False) as tmp:
-        tmp.write("x\ny\n")
-        name = tmp.name
-    try:
-        assert tail(name, 0) == [""]
-        assert tail(name, -5) == [""]
-    finally:
-        os.unlink(name)
+  # requesting more lines than available should return all lines
+  assert tail(file, 10) == ["a", "b", "c"]
+  assert tail(file, 3) == ["a", "b", "c"]
+  # requesting last two lines with small buffer to force multiple reads
+  assert tail(file, 2, bufsize = 1) == ["b", "c"]
+  assert tail(file, 1) == ["c"]
+  # zero or negative
+  assert tail(file, 0) == []
+  assert tail(file, -5) == []
 
 
 def test_process_branches(tmp_path):

--- a/tests/test_12_download.py
+++ b/tests/test_12_download.py
@@ -75,8 +75,12 @@ def test_download_extracts_and_sets_exec(tmp_path, monkeypatch):
         assert out_file.resolve() == cache_file
         # extracted content
         assert (build_dir / "inner.txt").read_text() == "data"
-        # executable bit set
-        assert out_file.stat().st_mode & stat.S_IXUSR
+
+        if os.name != 'nt':
+          # not settable on windows
+          # executable bit set
+          assert out_file.stat().st_mode & stat.S_IXUSR
+
         # info file exists
         info = cache_file.with_name(cache_file.name + ".info")
         assert info.exists()

--- a/tests/test_12_download.py
+++ b/tests/test_12_download.py
@@ -1,0 +1,105 @@
+import http.server
+import socketserver
+import threading
+import tarfile
+import hashlib
+import logging
+import os
+import stat
+from functools import partial
+from pathlib import Path
+
+import pytest
+
+import importlib
+
+download = importlib.import_module("partis.pyproj.builder.download")
+from partis.pyproj.validate import ValidationError
+
+
+class SilentHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, format, *args):
+        pass
+
+
+def start_server(directory: Path):
+    handler = partial(SilentHTTPRequestHandler, directory=str(directory))
+    httpd = socketserver.TCPServer(("localhost", 0), handler)
+    thread = threading.Thread(target=httpd.serve_forever)
+    thread.daemon = True
+    thread.start()
+    url = f"http://localhost:{httpd.server_address[1]}"
+    return httpd, thread, url
+
+
+def create_tar(directory: Path) -> tuple[Path, str]:
+    inner = directory / "inner.txt"
+    inner.write_text("data")
+    tar_path = directory / "file.tar"
+    with tarfile.open(tar_path, "w") as tf:
+        tf.add(inner, arcname="inner.txt")
+    digest = hashlib.sha256(tar_path.read_bytes()).hexdigest()
+    return tar_path, digest
+
+
+def test_cached_download_sanitizes_and_writes_info(tmp_path, monkeypatch):
+    monkeypatch.setattr(download, "CACHE_DIR", tmp_path)
+    url = "https://example.com/a b/c?d=e"
+    checksum = "sha256=deadbeef"
+    path = download._cached_download(url, checksum)
+    # ensure filename sanitized
+    assert " " not in str(path)
+    info = path.with_name(path.name + ".info")
+    assert info.read_text() == f"{url}\n{checksum}"
+
+
+def test_download_extracts_and_sets_exec(tmp_path, monkeypatch):
+    monkeypatch.setattr(download, "CACHE_DIR", tmp_path / "cache")
+    tar_path, digest = create_tar(tmp_path)
+    httpd, thread, base = start_server(tmp_path)
+    try:
+        url = f"{base}/file.tar"
+        build_dir = tmp_path / "build"
+        build_dir.mkdir()
+        logger = logging.getLogger("test")
+        opts = {
+            "url": url,
+            "checksum": f"sha256={digest}",
+            "extract": True,
+            "executable": True,
+        }
+        download.download(None, logger, opts, tmp_path, tmp_path, build_dir, tmp_path, [], [], [], False, runner=None)
+        cache_file = download._cached_download(url, f"sha256={digest}")
+        out_file = build_dir / "file.tar"
+        assert out_file.is_symlink()
+        assert out_file.resolve() == cache_file
+        # extracted content
+        assert (build_dir / "inner.txt").read_text() == "data"
+        # executable bit set
+        assert out_file.stat().st_mode & stat.S_IXUSR
+        # info file exists
+        info = cache_file.with_name(cache_file.name + ".info")
+        assert info.exists()
+    finally:
+        httpd.shutdown()
+        thread.join()
+
+
+def test_download_checksum_mismatch(tmp_path, monkeypatch):
+    monkeypatch.setattr(download, "CACHE_DIR", tmp_path / "cache")
+    tar_path, digest = create_tar(tmp_path)
+    httpd, thread, base = start_server(tmp_path)
+    try:
+        url = f"{base}/file.tar"
+        build_dir = tmp_path / "build"
+        build_dir.mkdir()
+        logger = logging.getLogger("test")
+        opts = {
+            "url": url,
+            "checksum": "sha256=" + "0" * 64,
+        }
+        with pytest.raises(ValidationError):
+            download.download(None, logger, opts, tmp_path, tmp_path, build_dir, tmp_path, [], [], [], False, runner=None)
+    finally:
+        httpd.shutdown()
+        thread.join()

--- a/tests/test_13_template_extra.py
+++ b/tests/test_13_template_extra.py
@@ -1,0 +1,39 @@
+from copy import copy
+from pathlib import Path
+
+import pytest
+
+from partis.pyproj import Namespace, template_substitute, FileOutsideRootError
+
+
+def test_namespace_copy_and_dirs(tmp_path):
+    root = tmp_path / "proj"
+    root.mkdir()
+    external = tmp_path / "external"
+    external.mkdir()
+    ns = Namespace({"root": root, "ext": external, "name": "abc"}, root=root, dirs=[external])
+    # path outside root but within allowed dirs
+    path = ns["root/../ext/'file.txt'"]
+    assert path == external / "file.txt"
+    # ensure copy is independent
+    ns2 = copy(ns)
+    ns2["name"] = "xyz"
+    assert ns2["name"] == "xyz"
+    assert ns["name"] == "abc"
+    # outside allowed dirs should raise
+    with pytest.raises(FileOutsideRootError):
+        ns["root/../'notallowed'/'file'"]
+
+
+def test_template_substitute_nested(tmp_path):
+    ns = {"name": "world", "num": 5, "dir": tmp_path}
+    value = {
+        "greet": "Hello ${name}",
+        "path": tmp_path / "${name}",
+        "items": ["${num}", {"inner": "${name}"}],
+    }
+    result = template_substitute(value, ns)
+    assert result["greet"] == "Hello world"
+    assert result["path"] == tmp_path / "world"
+    assert result["items"][0] == "5"
+    assert result["items"][1]["inner"] == "world"


### PR DESCRIPTION
## Summary
- cover download caching, extraction, and checksum validation
- test Namespace copying, directory allowances, and recursive template substitution

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d24053fcc8332a970360eb7fd1581