### PR TITLE
Add branch-coverage tests for template.py missing lines

### DIFF
--- a/tests/test_13_template_extra.py
+++ b/tests/test_13_template_extra.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from partis.pyproj import Namespace, template_substitute, FileOutsideRootError
+from partis.pyproj.template import Template, TemplateError, NamespaceError
 
 
 def test_namespace_copy_and_dirs(tmp_path):
@@ -23,6 +24,45 @@ def test_namespace_copy_and_dirs(tmp_path):
     # outside allowed dirs should raise
     with pytest.raises(FileOutsideRootError):
         ns["root/../'notallowed'/'file'"]
+
+
+def test_substitute_kwargs_only():
+    result = Template("${X}").substitute(X=10)
+    assert result == "10"
+
+
+def test_substitute_both_namespace_and_kwargs_raises():
+    with pytest.raises(TypeError, match="Cannot use both namespace and kwargs"):
+        Template("${X}").substitute({'X': 1}, Y=10)
+
+
+def test_substitute_plain_dict_wraps_as_namespace():
+    result = Template("${X}").substitute({'X': 10})
+    assert result == "10"
+
+
+def test_namespace_dirs_single_path():
+    d = Path('/some/dir')
+    ns = Namespace({}, dirs=d)
+    assert ns.dirs == [d]
+
+
+def test_namespace_iter_and_len():
+    ns = Namespace({'A': 1, 'B': 2})
+    assert set(iter(ns)) == {'A', 'B'}
+    assert len(ns) == 2
+
+
+def test_namespace_root_none_path_construction():
+    ns = Namespace({'dir': 'subdir'}, root=None)
+    result = ns["dir/'file.txt'"]
+    assert result == Path('subdir', 'file.txt')
+
+
+def test_namespace_nested_attr_on_scalar_raises():
+    ns = Namespace({'X': 42})
+    with pytest.raises(NamespaceError):
+        ns['X.Y']
 
 
 def test_template_substitute_nested(tmp_path):


### PR DESCRIPTION
Covers 9 previously uncovered lines in Template.substitute() and Namespace: kwargs-only call, namespace+kwargs TypeError, plain-dict auto-wrapping, single-Path dirs coercion, __iter__/__len__ delegation, root=None path construction, and nested access on a scalar value.